### PR TITLE
Added buildtree order UI

### DIFF
--- a/md/ut_cac_architect.xml
+++ b/md/ut_cac_architect.xml
@@ -125,7 +125,7 @@ Rest is shared between all Actor types
               </do_if>
               <open_conversation_menu menu="BuilderMacrosMenu" param="[0, 0, $actor, $actor.ship, 1]" param2="event.param3"/>
             </do_if>
-            
+			
             <do_elseif value="event.param == 'cArch_selectUpgradesMenu'">
               <add_conversation_view view="closeupdetailmonitor" />
               <do_if value="not $showed_cArch_selectUpgradesMenu?">
@@ -198,7 +198,7 @@ Rest is shared between all Actor types
               </do_if>
               <do_if value="$actor.ship.buildmodule.exists" comment="only available on builder ship">
                 <do_if value="$actor.ship.buildmodule.buildanchor.exists" comment="OR THERE ARE ALREADY BUILD ORDERS GIVEN!!!! "><!-- ToDo: Check for already given Orders in queue !!!!!! -->
-                  <add_player_choice text="'Extend Station (UI)'" position="1" section="comm_orders_extend_ui" selectable="false and $actor.$ut_cac.$orderedbuildplanlist" tooltip="'Not implemented yet'" comment="same Key as the Orders Menu and first Order for quick Access (Sequence 1 - 1 - 1 )" />
+                  <add_player_choice text="'Extend Station (UI)'" position="1" section="comm_orders_extend_ui" selectable="$actor.$ut_cac.$orderedbuildplanlist" comment="same Key as the Orders Menu and first Order for quick Access (Sequence 1 - 1 - 1 )" />
                   <add_player_choice text="'Extend Station (Dialogue)'" position="4" section="comm_orders_extend_dia" selectable="$actor.$ut_cac.$orderedbuildplanlist"/>
                 </do_if>
                 <do_else>
@@ -258,7 +258,7 @@ Rest is shared between all Actor types
                   <add_npc_line line="1124" comment="This is a list of all available modules for the station." view="closeupdetailmonitor" />
                 </do_else>
               </do_if>
-              <open_conversation_menu menu="BuildTreeMenu" param="[0, 0, $actor, $actor.ship, (not $actor.ship.buildmodule.isbuilding) and (not @$obstructioncheck), 'building', $actor.ship.buildmodule.buildanchor]" param2="event.param3" />
+              <open_conversation_menu menu="UTBuildTreeMenu" param="[0, 0, $actor, $actor.ship, (not $actor.ship.buildmodule.isbuilding) and (not @$obstructioncheck), $actor.ship.buildmodule.buildanchor]" param2="event.param3" />
             </do_elseif>
             <do_elseif value="event.param == 'comm_orders_extend_dia'">
               <do_if value="$actor.$ut_cac.$pesterlevel gt param.ut_cac.pesterlevel.$mayspeak">
@@ -283,6 +283,15 @@ Rest is shared between all Actor types
               <add_player_choice_return text="{5554103,7}" position="6" />
               <add_player_choice_return text="{5554103,7}" position="close" />
             </do_elseif>
+			<!-- UI: UT Buildcost select call -->
+            <do_elseif value="event.param == 'comm_orders_extend_ui_selected'">
+				<do_all exact="$actor.$ut_cac.$orderedbuildplanlist.count" counter="$i">
+					<do_if value="$actor.$ut_cac.$orderedbuildplanlist.{$i}.{1} == event.param2.{1}">
+						<set_value name="$actor.$ut_cac.$orderedbuildplanlist.{$i}.{2}" operation="add"/>
+						<set_value name="$new_order" exact="table[$script='ut.cac.com.architect.build',$displayname='Extend: Build %1'.[$stationmacro.buildpurposemacro.{buildplan.[event.param2.{1},$actor.$ut_cac.$orderedbuildplanlist.{$i}.{2}]}.name],$sequence=event.param2.{1},$upgradeplan=[],$interruptable=false]"/>
+					</do_if>
+				</do_all>
+			</do_elseif>
             <do_elseif value="event.param == 'comm_orders_extend_dia_selected'">
               <do_all exact="$actor.$ut_cac.$orderedbuildplanlist.count" counter="$i">
                 <do_if value="$actor.$ut_cac.$orderedbuildplanlist.{$i}.{1} == event.param2">

--- a/t/0001-l007.xml
+++ b/t/0001-l007.xml
@@ -125,6 +125,12 @@ will re-arrange stuff if a slot needs diffrent texts though
   <t id="556">%1Cr :Give twice the wanted Money as Kickstart</t>
   <t id="557"></t>
 </page>
+<page id="5554202" title="UT Command and Control UI Text" descr="UT Command and Control" voice="no">
+	<t id = "101">\033GСтроительство\033X</t>
+	<t id = "102">\033WЗавершено\033X</t>
+	<t id = "103">\033RРасширяемо\033X</t>
+	<t id = "104">\033YЗапланировано\033X</t>
+</page>
 <page id="5554203" title="UT Command and Control Player Feedback Messages" descr="UT Command and Control" voice="no">
   <!-- common First Line for all UT CAC Log Entries:
   %1 - Message Prio // %2 - Sender Container name // %3 - Sender Name -->

--- a/t/0001-l044.xml
+++ b/t/0001-l044.xml
@@ -125,6 +125,12 @@ will re-arrange stuff if a slot needs diffrent texts though
   <t id="556">%1Cr :Give twice the wanted Money as Kickstart</t>
   <t id="557"></t>
 </page>
+<page id="5554202" title="UT Command and Control UI Text" descr="UT Command and Control" voice="no">
+	<t id = "101">\033GBuilding\033X</t>
+	<t id = "102">\033WCompleted\033X</t>
+	<t id = "103">\033RExtendable\033X</t>
+	<t id = "104">\033YScheduled\033X</t>
+</page>
 <page id="5554203" title="UT Command and Control Player Feedback Messages" descr="UT Command and Control" voice="no">
   <!-- common First Line for all UT CAC Log Entries:
   %1 - Message Prio // %2 - Sender Container name // %3 - Sender Name -->

--- a/t/0001-l049.xml
+++ b/t/0001-l049.xml
@@ -125,6 +125,12 @@ will re-arrange stuff if a slot needs diffrent texts though
   <t id="556">%1Cr :Give twice the wanted Money as Kickstart</t>
   <t id="557"></t>
 </page>
+<page id="5554202" title="UT Command and Control UI Text" descr="UT Command and Control" voice="no">
+	<t id = "101">\033GAufbauen\033X</t>
+	<t id = "102">\033WFertiggestellt\033X</t>
+	<t id = "103">\033RErweiterbar\033X</t>
+	<t id = "104">\033YGeplant\033X</t>
+</page>
 <page id="5554203" title="UT Command and Control Player Feedback Messages" descr="UT Command and Control" voice="no">
   <!-- common First Line for all UT CAC Log Entries:
   %1 - Message Prio // %2 - Sender Container name // %3 - Sender Name -->

--- a/t/0001.xml
+++ b/t/0001.xml
@@ -125,6 +125,11 @@ will re-arrange stuff if a slot needs diffrent texts though
   <t id="556">%1Cr :Give twice the wanted Money as Kickstart</t>
   <t id="557"></t>
 </page>
+<page id="5554202" title="UT Command and Control UI Text" descr="UT Command and Control" voice="no">
+	<t id = "101">\033GBuilding\033X</t>
+	<t id = "102">\033WCompleted\033X</t>
+	<t id = "103">\033RExtendable\033X</t>
+</page>
 <page id="5554203" title="UT Command and Control Player Feedback Messages" descr="UT Command and Control" voice="no">
   <!-- common First Line for all UT CAC Log Entries:
   %1 - Message Prio // %2 - Sender Container name // %3 - Sender Name -->

--- a/ui.xml
+++ b/ui.xml
@@ -3,6 +3,7 @@
   <environment type="detailmonitor">
     <file name="ui/ut_menu_map.lua" />
     <file name="ui/ut_conversationcontrol.lua" />
+    <file name="ui/ut_buildtree.lua" />
     <dependency name="ego_detailmonitor" />
     <!--bindings context="INPUT_CONTEXT_ADDON_DETAILMONITOR" alwaysactive="false">
       <binding action="INPUT_ACTION_ADDON_DETAILMONITOR_G" />

--- a/ui/ut_buildtree.lua
+++ b/ui/ut_buildtree.lua
@@ -1,0 +1,300 @@
+
+-- param == {0,0,architect, buildership, canbuild, station }
+
+local menu = {
+	name = "UTBuildTreeMenu",
+	defaultColor = { r = 255, g = 255, b = 255, a = 100 },
+	availColor = { r = 0, g = 192, b = 0, a = 100 },
+	buildingColor = { r = 192, g = 192, b = 0, a = 100 },
+	textwidth = 632,
+	fullwidth = 792,
+	transparent = { r = 0, g = 0, b = 0, a = 0 },
+	red = { r = 255, g = 0, b = 0, a = 100 }
+}
+
+local function init()
+	Menus = Menus or { }
+	table.insert(Menus, menu)
+	if Helper then
+		Helper.registerMenu(menu)
+	end
+end
+
+function menu.cleanup()
+	menu.architect = nil
+	menu.buildership = nil
+	menu.canbuild = nil
+	menu.station = nil
+end
+
+function menu.onShowMenu()
+	--Importing params
+	menu.architect = menu.param[3]
+	menu.buildership = menu.param[4]
+	menu.canbuild = menu.param[5]
+	menu.station = menu.param[6]
+	--Getting macros
+	menu.stationmacro = GetComponentData(menu.station, "macro")
+	local title = ReadText(1001,1700)
+	--Getting global UI information
+	local productioncolor, buildcolor, storagecolor, radarcolor, dronedockcolor, efficiencycolor, defencecolor = GetHoloMapColors()	
+	--Creating UI Skeleton
+	--Description at the top
+	local setup  = Helper.createTableSetup(menu)
+	local name, typestring, typeicon, typename, ownericon = GetComponentData(menu.architect, "name", "typestring", "typeicon", "typename", "ownericon")
+	setup:addTitleRow{
+		Helper.createIcon(typeicon, false, 255, 255, 255, 100, 0, 0, Helper.headerCharacterIconSize, Helper.headerCharacterIconSize),
+		Helper.createFontString(typename .. " " .. name, false, "left", 255, 255, 255, 100, Helper.headerRow1Font, Helper.headerRow1FontSize),
+		Helper.createIcon(ownericon, false, 255, 255, 255, 100, 0, 0, Helper.headerCharacterIconSize, Helper.headerCharacterIconSize)
+	}
+	local infodesc = setup:createCustomWidthTable({ Helper.scaleX(Helper.headerCharacterIconSize), 0, Helper.scaleX(Helper.headerCharacterIconSize) + 37 }, false, true)
+	--Buildtree itself! NOOOO!!!! PAIN!!! SUFFERRING!!!
+	--Some buildtree data
+	local cursequence, curstage, curprogress = GetCurrentBuildSlot(menu.station)
+	local sortedbuildorder_blackboard = GetNPCBlackboard(menu.architect, "$ut_cac")
+	local utcac_buildplan = sortedbuildorder_blackboard.orderedbuildplanlist;
+	menu.buildtree = GetBuildTree(menu.station)
+	--Rebuilding the buildtree
+	local entries = {}
+	for seqidx, seqdata in ipairs(menu.buildtree) do
+		entries[seqidx] = {}
+		entries[seqidx].currentsequence = seqdata.sequence
+		entries[seqidx].currentstage = seqdata.currentstage
+		entries[seqidx].seqname = "SEQ: " .. seqdata.sequence
+		
+		-- Naming identities
+		local numproductions, numbuild, numstorages, numradar, numdronelaunchpad = 0, 0, 0, 0, 0
+		local productionname = ""
+		
+		--Special base sequence(zero sequence)
+		if seqdata.sequence == "a" then
+			DebugError("Positive seq!")
+			modules = GetBuildStageModules(menu.station, "", 0)
+			seqAidx=seqidx 
+			entries[seqidx][0] = {}
+			entries[seqidx][0].stagename = stagestring
+			entries[seqidx][0].stageid = 0
+			entries[seqidx][0].isCompleted = true
+			entries[seqidx][0].isBuildingThis = false
+			entries[seqidx][0].isScheduled = false
+			entries[seqidx][0].isExtendable = false
+			fillModules(entries, modules, seqidx, 0)
+		end
+		--General stages
+		for stageidx, stagedata in ipairs(seqdata) do
+			entries[seqidx][stageidx] = {}
+			entries[seqidx][stageidx].stagename = stagestring
+			entries[seqidx][stageidx].stageid = stagedata.stage
+			entries[seqidx][stageidx].sequenceid = seqdata.sequence
+			local isCompleted = false
+			
+			modules = GetBuildStageModules(menu.station, seqdata.sequence, stagedata.stage)
+			local temp_prodname = fillModules(entries, modules, seqidx, stageidx)
+			if temp_prodname ~= "" then productionname = temp_prodname end
+			
+			numproductions = numproductions + modules.numproductions
+			numbuild = numbuild + modules.numbuild
+			numstorages = numstorages + modules.numstorages
+			numradar = numradar + modules.numradar
+			numdronelaunchpad = numdronelaunchpad + modules.numdronelaunchpad
+			
+			if entries[seqidx].currentstage >= stageidx then isCompleted = true end
+			-- TODO: Query UTCAC Buildorder ($actor.$ut_cac.$orderedbuildplanlist)
+			local isBuildingThis = false
+			if cursequence == seqdata.sequence then
+				if curstage == stagedata.stage then
+					isBuildingThis = true
+				end
+			end
+			local isExtendable = false
+			local isScheduled = false
+			for _,bp in ipairs(utcac_buildplan) do
+				if bp[1] == seqdata.sequence then
+					if (bp[2] + 1) == stagedata.stage then
+						isExtendable = true
+					elseif stagedata.stage < (bp[2] + 1) then
+						if isCompleted ~= true then
+							isScheduled = true
+						end
+					end
+				end
+			end
+			-- TODO: This mess above should be a function
+			entries[seqidx][stageidx].isCompleted = isCompleted
+			entries[seqidx][stageidx].isBuildingThis = isBuildingThis
+			entries[seqidx][stageidx].isScheduled = isScheduled
+			entries[seqidx][stageidx].isExtendable = isExtendable
+		end
+		--Seq virtual name
+		if numproductions > 0 or numbuild > 0 then
+			entries[seqidx].seqname = "   " .. productionname
+		elseif numstorages > 0 then
+			entries[seqidx].seqname = "   " .. ReadText(1001, 1400)
+		elseif numradar > 0 then
+			entries[seqidx].seqname = "   " .. ReadText(1001, 1706)
+		elseif numdronelaunchpad > 0 then
+			entries[seqidx].seqname = "   " .. ReadText(1001, 1707)
+		else
+			entries[seqidx].seqname = "   " .. ReadText(1001, 1310)
+		end
+	end
+	--Stage 0 uplift
+	table.insert(entries[seqAidx],entries[seqAidx][0])
+	entries[seqAidx][0] = nil
+	--Finalization
+	table.sort(entries, function (a, b) return a.currentsequence < b.currentsequence end)
+	for _,sequence  in ipairs(entries) do
+		table.sort(sequence, function (a, b) return a.stageid < b.stageid end)
+	end
+	--Buildtree presentation
+	setup = Helper.createTableSetup(menu)
+	for seqidx, sequence in ipairs(entries) do
+		setup:addSimpleRow({sequence.seqname, Helper.getEmptyCellDescriptor()},nil,{2,1}, false, Helper.defaultHeaderBackgroundColor)
+		for stageidx, stage in ipairs(sequence) do
+			local buildStateText = menu.getBuildStateText(stage)
+			--..sequence.currentstage.."-"..sequence.currentstage
+			setup:addSimpleRow({ 
+				"       " .. ReadText(1001, 1701) .. " " .. stage.stageid,
+				Helper.createFontString(buildStateText , false, "left")
+			},{sequence = sequence.currentsequence, stage = stage.stageid, stagedescriptor = stage, isExtendable = stage.isExtendable}, {2,1}, false, Helper.defaultHeaderBackgroundColor)
+			for moduleidx, module in ipairs(stage) do
+				setup:addSimpleRow({ "", Helper.createFontString(module.name, false, "left", module.color.r, module.color.g,module.color.b,module.color.a), Helper.getEmptyCellDescriptor()}, module, {1,1,1})
+			end
+		end
+	end
+	local selectdesc = setup:createCustomWidthTable({ Helper.standardButtonWidth, menu.textwidth, 0 }, false, false, true, 1, 0, 0, Helper.tableOffsety, 445)
+	--Buttons on the bottom
+	setup = Helper.createTableSetup(menu)
+	setup:addTitleRow({Helper.getEmptyCellDescriptor()}, nil, {9})
+	setup:addSimpleRow({ 
+		Helper.getEmptyCellDescriptor(),
+		Helper.createButton(Helper.createButtonText(ReadText(1001, 2669), "center", Helper.standardFont, Helper.standardFontSize, 255, 255, 255, 100), nil, false, true, 0, 0, 150, 25, nil, Helper.createButtonHotkey("INPUT_STATE_DETAILMONITOR_B", true)),
+		Helper.getEmptyCellDescriptor(),
+		Helper.getEmptyCellDescriptor(),
+		Helper.getEmptyCellDescriptor(),
+		Helper.getEmptyCellDescriptor(),
+		Helper.getEmptyCellDescriptor(),
+		--Button below by default is grayed out, awaiting selection ;)
+		Helper.createButton(Helper.createButtonText(ReadText(1001, 1708), "center", Helper.standardFont, Helper.standardFontSize, 255, 255, 255, 100), nil, false, false, 0, 0, 150, 25, nil, Helper.createButtonHotkey("INPUT_STATE_DETAILMONITOR_X", true)),
+		Helper.getEmptyCellDescriptor()
+	}, nil, nil, false, menu.transparent)
+	local buttondesc = setup:createCustomWidthTable({48, 150, 48, 150, 0, 150, 48, 150, 48}, false, false, true, 2, 2, 0, 520, 0, false)
+	--Commiting
+	menu.infotable, menu.selecttable, menu.buttontable = Helper.displayThreeTableView(menu, infodesc, selectdesc, buttondesc, false)
+	
+	--Button scripts
+	Helper.setButtonScript(menu, nil, menu.buttontable, 2, 2, function () return menu.onCloseElement("back") end)
+	Helper.setButtonScript(menu, nil, menu.buttontable, 2, 8, menu.buttonExtend)
+	
+	if menu.station then
+		menu.onUpdate()
+	end
+	
+end
+
+function menu.buttonExtend()
+	local rowdata = menu.rowDataMap[Helper.currentDefaultTableRow]
+	if rowdata then
+		if rowdata.sequence then
+			Helper.closeMenuForSection(menu, false, "comm_orders_extend_ui_selected", {rowdata.sequence})
+			menu.cleanup()
+		end
+	end
+end
+
+menu.updateInterval = 1.0
+
+function menu.onRowChanged(row, rowdata)
+	local rowdata = menu.rowDataMap[Helper.currentDefaultTableRow]
+	if rowdata then
+		Helper.removeButtonScripts(menu, menu.buttontable, 2, 8)
+		local isEnabled = false
+		if rowdata.isExtendable then
+			isEnabled = rowdata.isExtendable
+		end
+		SetCellContent(menu.buttontable, Helper.createButton(Helper.createButtonText(ReadText(1001, 1708), "center", Helper.standardFont, Helper.standardFontSize, 255, 255, 255, 100), nil, false, isEnabled, 0, 0, 150, 25, nil, Helper.createButtonHotkey("INPUT_STATE_DETAILMONITOR_X", true)), 2, 8)
+		Helper.setButtonScript(menu, nil, menu.buttontable, 2, 8, menu.buttonExtend)	
+	end
+end
+
+function menu.getBuildStateText(stage)
+	buildStateText = ""
+	if stage.isScheduled then buildStateText = ReadText(5554202, 104) end
+	if stage.isExtendable then buildStateText = ReadText(5554202, 103) end
+	if stage.isCompleted then buildStateText = ReadText(5554202, 102) end
+	if stage.isBuildingThis then buildStateText = ReadText(5554202, 101) end
+	return buildStateText
+end
+
+function menu.onUpdate()
+	if menu.station and menu.rowDataMap then
+		-- Update station's current build status, and the "available" flag
+		local cursequence, curstage, curprogress = GetCurrentBuildSlot(menu.station)
+		for row, rowdata in pairs(menu.rowDataMap) do
+			if rowdata then
+				if rowdata.stagedescriptor then
+					if cursequence == rowdata.sequence and curstage == rowdata.stage then
+						rowdata.stagedescriptor.isBuildingThis = true
+					else
+						if rowdata.stagedescriptor.isBuildingThis == true then
+							--Assuming the process for successful
+							--TODO: Account for CV destruction
+							rowdata.stagedescriptor.isScheduled = false
+							rowdata.stagedescriptor.isCompleted = true
+						end
+						rowdata.stagedescriptor.isBuildingThis = false
+					end
+					buildStateText = menu.getBuildStateText(rowdata.stagedescriptor)
+					if rowdata.stagedescriptor.isBuildingThis == true then
+						buildStateText = string.format("%s (%d %%)", buildStateText, curprogress)
+					end
+					Helper.updateCellText(menu.selecttable, row, 3, buildStateText)
+				end
+			end
+		end
+	end
+end
+
+function menu.onSelectElement()
+end
+
+function menu.onCloseElement(dueToClose)
+	if dueToClose == "close" then
+		Helper.closeMenuAndCancel(menu)
+		menu.cleanup()
+	else
+		Helper.closeMenuAndReturn(menu)
+		menu.cleanup()
+	end
+end
+
+function fillModules(entries, modules, seqidx, stageidx)
+	local productionname = ""
+	local productioncolor, buildcolor, storagecolor, radarcolor, dronedockcolor, efficiencycolor, defencecolor = GetHoloMapColors()	
+	for moduleidx, module in ipairs(modules) do
+		local color = {r = 255, g = 255, b = 255, a = 100}
+		if module.library == "moduletypes_production" then
+			color = productioncolor
+			productionname = module.name
+		elseif module.library == "moduletypes_build" then
+			color = buildcolor
+			productionname = module.name
+		elseif module.library == "moduletypes_storage" then
+			color = storagecolor
+		elseif module.library == "moduletypes_communication" then
+			color = radarcolor
+		elseif module.library == "moduletypes_dronedock" then
+			color = dronedockcolor
+		elseif module.library == "moduletypes_efficiency" then
+			color = efficiencycolor
+		elseif module.library == "moduletypes_defence" then
+			color = defencecolor
+		end
+		entries[seqidx][stageidx][moduleidx] = {name = module.name}
+		entries[seqidx][stageidx][moduleidx].color = color
+		AddKnownItem(module.library, module.macro)
+	end
+	return productionname
+end
+
+init()


### PR DESCRIPTION
May require some naming changes to accommodate your style, but it is done.

Known issues: 
- No idea what will happen if CV, station(extreme modded circumstances \o/) or architect are destroyed when UI is open. I haven't found any special handling in vanilla.
- Is missing vanilla encyclopedia buttons for modules(probably will add them later)
- Added new page to text file to account UI text. Might require some rearrangements to fit your allocated page range.
- Doesn't reevaluate stage orders while UI is open(will ignore current build-queue and confuse order-queue if order is committed by third-party). Will probably need a signal to respond when order queue is changed and requires reevaluation.
- Bottom statusbar is empty. It is possible to add information there, but I have no idea what kind of info it would make sense to have(local economy resource cost for selected stage?)
